### PR TITLE
feat: add ability to set minimum SUDT cell capacity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sudt-cli",
       "version": "0.5.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lay2/pw-core": "^0.4.0-alpha.8",
+        "@lay2/pw-core": "0.4.0-alpha.12",
         "@nervosnetwork/ckb-sdk-utils": "^0.43.0",
         "@types/lodash": "^4.14.171",
         "@types/mkdirp": "^1.0.2",
@@ -503,9 +504,9 @@
       }
     },
     "node_modules/@lay2/pw-core": {
-      "version": "0.4.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@lay2/pw-core/-/pw-core-0.4.0-alpha.8.tgz",
-      "integrity": "sha512-8noTtfWybQJ5ZDJCqJw753oUB8ttjwE2u0kBw5at7YPxtEGdPsZslWdMK7gVn6XaKNfYTgQKhxYYPk3CBVZNtA==",
+      "version": "0.4.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@lay2/pw-core/-/pw-core-0.4.0-alpha.12.tgz",
+      "integrity": "sha512-3TJkRx5W+Dr+OFxKUGwgoN949LloVIA9TQUsPnQ4GCGdrj87s0mWMi/gnr74nBr5RJayPfOFY7oBfRTschCRrg==",
       "dependencies": {
         "@nervosnetwork/ckb-sdk-utils": "^0.41.1",
         "@scatterjs/core": "^2.7.53",
@@ -7578,9 +7579,9 @@
       }
     },
     "@lay2/pw-core": {
-      "version": "0.4.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@lay2/pw-core/-/pw-core-0.4.0-alpha.8.tgz",
-      "integrity": "sha512-8noTtfWybQJ5ZDJCqJw753oUB8ttjwE2u0kBw5at7YPxtEGdPsZslWdMK7gVn6XaKNfYTgQKhxYYPk3CBVZNtA==",
+      "version": "0.4.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@lay2/pw-core/-/pw-core-0.4.0-alpha.12.tgz",
+      "integrity": "sha512-3TJkRx5W+Dr+OFxKUGwgoN949LloVIA9TQUsPnQ4GCGdrj87s0mWMi/gnr74nBr5RJayPfOFY7oBfRTschCRrg==",
       "requires": {
         "@nervosnetwork/ckb-sdk-utils": "^0.41.1",
         "@scatterjs/core": "^2.7.53",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sudt-cli",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "description": "sudt-cli is a command line tool to create SUDT tokens on the Nervos Mainnet, Testnet, and on private Devnets.",
   "main": "bin/sudt-cli.js",
   "bin": {
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/jordanmack/sudt-cli#readme",
   "dependencies": {
-    "@lay2/pw-core": "^0.4.0-alpha.8",
+    "@lay2/pw-core": "0.4.0-alpha.12",
     "@nervosnetwork/ckb-sdk-utils": "^0.43.0",
     "@types/lodash": "^4.14.171",
     "@types/mkdirp": "^1.0.2",

--- a/src/SudtBuilder.ts
+++ b/src/SudtBuilder.ts
@@ -10,7 +10,7 @@ export default class SudtBuilder extends Builder
 	collector: BasicCollector;
 	fee: Amount;
 
-	constructor(sudt: SUDT, issuerAddress: Address, destinationAddress: Address, amount: Amount, collector: BasicCollector, fee: Amount)
+	constructor(sudt: SUDT, issuerAddress: Address, destinationAddress: Address, amount: Amount, collector: BasicCollector, fee: Amount, public minimumSudtCellCapacity: Amount)
 	{
 		super();
 
@@ -42,6 +42,11 @@ export default class SudtBuilder extends Builder
 		const lockScript = destinationAddress.toLockScript();
 		const sudtCell = new Cell(new Amount("9999999999", AmountUnit.ckb), lockScript, typeScript, undefined, amount.toUInt128LE());
 		sudtCell.capacity = sudtCell.occupiedCapacity();
+
+		if (sudtCell.capacity.lt(this.minimumSudtCellCapacity)) {
+			sudtCell.capacity = this.minimumSudtCellCapacity;
+		}
+
 		outputCells.push(sudtCell);
 
 		// Calculate the required capacity. (SUDT cell + change cell minimum (61) + fee)


### PR DESCRIPTION
Add ability to set minimum SUDT cell capacity so it's possible to issue SUDT straight to Layer 2 deposit address. This is useful for example when working with Godwoken devnet and depositing SUDT straight to Layer 2.